### PR TITLE
Multiexp

### DIFF
--- a/src/aggregation/multiple.rs
+++ b/src/aggregation/multiple.rs
@@ -134,10 +134,8 @@ pub fn aggregate_claims<F: PrimeField, CS: PCS<F>, T: Transcript<F, CS::C>>(
 
     let (coeffs, normalizer) = get_coeffs(zs_at_zeta, gamma);
 
-    //TODO: multiexp
-    let agg_c: CS::C = claims.iter().zip(coeffs.iter())
-        .map(|(claim, &coeff)| claim.c.mul(coeff))
-        .sum();
+    let commitments = claims.into_iter().map(|cl| cl.c).collect::<Vec<_>>();
+    let agg_c: CS::C = CS::C::combine(&coeffs, &commitments);
 
     let agg_r_at_zeta: F = rs_at_zeta.into_iter().zip(coeffs.iter())
         .map(|(ri_at_zeta, coeff)| ri_at_zeta * coeff)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,15 +128,19 @@ mod tests {
     use super::*;
     use ark_ec::PairingEngine;
 
+    pub(crate) type TestCurve = ark_bls12_381::Bls12_381;
+    pub(crate) type TestField = <TestCurve as PairingEngine>::Fr;
+    pub(crate) type TestKzg = KZG::<TestCurve>;
+
     pub(crate) type BenchCurve = ark_bw6_761::BW6_761;
     pub(crate) type BenchField = <BenchCurve as PairingEngine>::Fr;
 
     #[allow(dead_code)] // used by ignored tests
     pub(crate) type BenchKzg = KZG::<BenchCurve>;
 
-    pub(crate) type TestCurve = ark_bls12_381::Bls12_381;
-    pub(crate) type TestField = <TestCurve as PairingEngine>::Fr;
-    pub(crate) type TestKzg = KZG::<TestCurve>;
+    pub const BENCH_DEG_LOG1: usize = 10;
+    pub const BENCH_DEG_LOG2: usize = 16;
+    // const BENCH_DEG_LOG3: usize = 24; Eth 2.0 coming?
 
     fn generate_test_data<R, F>(
         rng: &mut R,

--- a/src/pcs/kzg/commitment.rs
+++ b/src/pcs/kzg/commitment.rs
@@ -8,6 +8,7 @@ use ark_ec::ProjectiveCurve;
 
 use ark_serialize::*;
 use ark_std::io::{Read, Write};
+use crate::utils::ec::small_multiexp_proj;
 
 
 /// KZG commitment to G1 represented in projective coordinates.
@@ -19,6 +20,12 @@ impl <E: PairingEngine> Commitment<E::Fr> for KzgCommitment<E> {
     fn mul(&self, by: E::Fr) -> KzgCommitment<E> {
         let x: E::G1Projective = self.0.mul(by.into_repr());
         KzgCommitment(x)
+    }
+
+    fn combine(coeffs: &[<E as PairingEngine>::Fr], commitments: &[Self]) -> Self {
+        let bases = commitments.iter().map(|c| c.0).collect::<Vec<_>>();
+        let prod = small_multiexp_proj(coeffs, bases.as_slice());
+        KzgCommitment(prod)
     }
 }
 

--- a/src/pcs/mod.rs
+++ b/src/pcs/mod.rs
@@ -19,6 +19,7 @@ Eq
 + Sum<Self>
 {
     fn mul(&self, by: F) -> Self;
+    fn combine(coeffs: &[F], commitments: &[Self]) -> Self;
 }
 
 
@@ -77,6 +78,7 @@ pub(crate) mod tests {
     use crate::Poly;
 
     use super::*;
+    use crate::utils::poly;
 
     #[derive(Clone, PartialEq, Eq, Debug)]
     pub struct WrappedPolynomial<F: PrimeField>(pub Poly<F>);
@@ -116,6 +118,12 @@ pub(crate) mod tests {
             let mut temp = Poly::zero(); //TODO
             temp += (by, &self.0);
             WrappedPolynomial(temp)
+        }
+
+        fn combine(coeffs: &[F], commitments: &[Self]) -> Self {
+            let polys = commitments.to_vec().into_iter().map(|c| c.0).collect::<Vec<_>>();
+            let combined = poly::sum_with_coeffs(coeffs.to_vec(), &polys);
+            WrappedPolynomial(combined)
         }
     }
 


### PR DESCRIPTION
addresses https://github.com/w3f/fflonk/issues/20
skipping exp=1 is not necessary, in the current multiexp impl it has no overhead

> cargo test bench_aggregation --release --features "parallel print-trace" -- --nocapture --ignored

```
Start:   Aggregate 8 degree-1023 polynomials
··Start:   polynomial divisions
··End:     polynomial divisions ....................................................5.288ms
··Start:   commitment to a degree-1022 polynomial
··End:     commitment to a degree-1022 polynomial ..................................83.750ms
··Start:   linear combination of polynomials
··End:     linear combination of polynomials .......................................1.078ms
End:     Aggregate 8 degree-1023 polynomials .......................................94.045ms
Start:   Aggregate 8 claims
··Start:   barycentric evaluations
··End:     barycentric evaluations .................................................432.300µs
··Start:   multiexp
··End:     multiexp ................................................................8.301ms
End:     Aggregate 8 claims ........................................................9.399ms
```
on BW6