### PR TITLE
PCS::PARAMS::raw_vk()

### DIFF
--- a/src/pcs/id/mod.rs
+++ b/src/pcs/id/mod.rs
@@ -67,13 +67,29 @@ impl VerifierKey for () {
     }
 }
 
+impl RawVerifierKey for () {
+    type VK = ();
 
-impl PcsParams<(), ()> for () {
+    fn prepare(&self) -> () {
+        ()
+    }
+}
+
+
+impl PcsParams for () {
+    type CK = ();
+    type VK = ();
+    type RVK = ();
+
     fn ck(&self) -> () {
         ()
     }
 
     fn vk(&self) -> () {
+        ()
+    }
+
+    fn raw_vk(&self) -> () {
         ()
     }
 }
@@ -83,10 +99,10 @@ pub struct IdentityCommitment {}
 
 impl<F: PrimeField> PCS<F> for IdentityCommitment {
     type C = WrappedPolynomial<F>;
-    type Params = ();
     type Proof = ();
     type CK = ();
     type VK = ();
+    type Params = ();
 
     fn setup<R: Rng>(_max_degree: usize, _rng: &mut R) -> Self::Params {
         ()

--- a/src/pcs/kzg/params.rs
+++ b/src/pcs/kzg/params.rs
@@ -1,14 +1,27 @@
 use ark_ec::{PairingEngine, AffineCurve};
-use crate::pcs::{PcsParams, CommitterKey, VerifierKey};
+use crate::pcs::{PcsParams, CommitterKey, VerifierKey, RawVerifierKey};
 use crate::pcs::kzg::urs::URS;
 
 use ark_serialize::*;
 
 
+impl<E: PairingEngine> PcsParams for URS<E> {
+    type CK = KzgCommitterKey<E::G1Affine>;
+    type VK = KzgVerifierKey<E>;
+    type RVK = RawKzgVerifierKey<E>;
 
-impl<E: PairingEngine> URS<E> {
+    fn ck(&self) -> KzgCommitterKey<E::G1Affine> {
+        KzgCommitterKey {
+            powers_in_g1: self.powers_in_g1.clone() //TODO: Cow?
+        }
+    }
+
+    fn vk(&self) -> KzgVerifierKey<E> {
+        self.raw_vk().prepare()
+    }
+
     /// Non-prepared verifier key. Can be used for serialization.
-    pub fn raw_vk(&self) -> RawKzgVerifierKey<E> {
+    fn raw_vk(&self) -> Self::RVK {
         assert!(self.powers_in_g1.len() > 0, "no G1 generator");
         assert!(self.powers_in_g2.len() > 1, "{} powers in G2", self.powers_in_g2.len());
 
@@ -19,20 +32,6 @@ impl<E: PairingEngine> URS<E> {
         }
     }
 }
-
-impl<E: PairingEngine> PcsParams<KzgCommitterKey<E::G1Affine>, KzgVerifierKey<E>> for URS<E> {
-    fn ck(&self) -> KzgCommitterKey<E::G1Affine> {
-        KzgCommitterKey {
-            powers_in_g1: self.powers_in_g1.clone() //TODO: Cow?
-        }
-    }
-
-    fn vk(&self) -> KzgVerifierKey<E> {
-        self.raw_vk().prepare()
-    }
-}
-
-
 
 
 /// Used to commit to and to open univariate polynomials of degree up to self.max_degree().
@@ -49,21 +48,25 @@ impl<G: AffineCurve> CommitterKey for KzgCommitterKey<G> {
 }
 
 
-
 /// Verifier key with G2 elements not "prepared". Exists only to be serializable.
 /// KzgVerifierKey is used for verification.
 #[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
 pub struct RawKzgVerifierKey<E: PairingEngine> {
-    g1: E::G1Affine, // generator of G1
-    g2: E::G2Affine, // generator of G2
+    g1: E::G1Affine,
+    // generator of G1
+    g2: E::G2Affine,
+    // generator of G2
     tau_in_g2: E::G2Affine, // tau.g2
 }
 
-impl<E: PairingEngine> RawKzgVerifierKey<E> {
+
+impl<E: PairingEngine> RawVerifierKey for RawKzgVerifierKey<E> {
+    type VK = KzgVerifierKey<E>;
+
     /// Returns the key that is used to verify openings in a single point. It has points in G2 "prepared".
     /// "Preparation" is a pre-computation that makes pairing computation with these points more efficient.
     /// At the same time usual arithmetic operations are not implemented for "prepared" points.
-    pub fn prepare(&self) -> KzgVerifierKey<E> {
+    fn prepare(&self) -> KzgVerifierKey<E> {
         KzgVerifierKey {
             g1: self.g1,
             g2: self.g2.into(),
@@ -73,24 +76,23 @@ impl<E: PairingEngine> RawKzgVerifierKey<E> {
 }
 
 
-
 /// "Prepared" verifier key capable of verifying opening in a single point, given the commitment is in G1.
 /// Use RawKzgVerifierKey for serialization.
 #[derive(Clone, Debug)]
 pub struct KzgVerifierKey<E: PairingEngine> {
     // generator of G1
-    pub(crate) g1: E::G1Affine, // G1Prepared is just a wrapper around G1Affine // TODO: fixed-base precomputations
+    pub(crate) g1: E::G1Affine,
+    // G1Prepared is just a wrapper around G1Affine // TODO: fixed-base precomputations
     // generator of G2, prepared
-    pub(crate) g2: E::G2Prepared, // G2Prepared can be used as a pairing RHS only
+    pub(crate) g2: E::G2Prepared,
+    // G2Prepared can be used as a pairing RHS only
     // tau.g2, prepared
     pub(crate) tau_in_g2: E::G2Prepared, // G2Prepared can be used as a pairing RHS only
 }
 
-impl<E: PairingEngine> VerifierKey for KzgVerifierKey<E> {
+impl<E: PairingEngine> VerifierKey for KzgVerifierKey<E> {}
 
-}
-
-impl<E:PairingEngine> From<KzgVerifierKey<E>> for KzgCommitterKey<E::G1Affine> {
+impl<E: PairingEngine> From<KzgVerifierKey<E>> for KzgCommitterKey<E::G1Affine> {
     fn from(vk: KzgVerifierKey<E>) -> Self {
         KzgCommitterKey {
             powers_in_g1: vec![vk.g1]

--- a/src/pcs/mod.rs
+++ b/src/pcs/mod.rs
@@ -49,9 +49,22 @@ pub trait VerifierKey: Clone + Debug {
 }
 
 
-pub trait PcsParams<CK, VK> {
-    fn ck(&self) -> CK; //TODO: trim
-    fn vk(&self) -> VK;
+/// Generates a `VerifierKey`, serializable
+pub trait RawVerifierKey: Clone + Debug + CanonicalSerialize + CanonicalDeserialize {
+    type VK: VerifierKey;
+
+    fn prepare(&self) -> Self::VK;
+}
+
+
+pub trait PcsParams {
+    type CK: CommitterKey;
+    type VK: VerifierKey;
+    type RVK: RawVerifierKey<VK=Self::VK>;
+
+    fn ck(&self) -> Self::CK; //TODO: trim
+    fn vk(&self) -> Self::VK;
+    fn raw_vk(&self) -> Self::RVK;
 }
 
 
@@ -63,7 +76,7 @@ pub trait PCS<F: PrimeField> {
 
     type CK: CommitterKey;
     type VK: VerifierKey + Into<Self::CK>;
-    type Params: PcsParams<Self::CK, Self::VK>;
+    type Params: PcsParams<CK=Self::CK, VK=Self::VK>;
 
     fn setup<R: Rng>(max_degree: usize, rng: &mut R) -> Self::Params;
 


### PR DESCRIPTION
Appeared required for Fiat-Shamir, as vk has G2 bases in prepared form