### PR TITLE
Disable default features for no-std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ ark-poly = { version = "0.4", default-features = false }
 ark-serialize = { version = "0.4", default-features = false, features = ["derive"] }
 
 rayon = { version = "1", optional = true }
-merlin = "3.0"
+merlin = { version = "3.0", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -34,6 +34,6 @@ harness = true
 [features]
 default = []
 asm = ["ark-ff/asm"]
-std = ["ark-std/std", "ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-serialize/std"]
+std = ["ark-std/std", "ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-serialize/std", "merlin/std"]
 parallel = ["std", "rayon", "ark-std/parallel", "ark-ff/parallel", "ark-ec/parallel", "ark-poly/parallel"]
 print-trace = ["ark-std/print-trace"]


### PR DESCRIPTION
Complains for `getrandom` inclusion
