### PR TITLE
Types required to be clonable to have a clonable ring-proof

### DIFF
--- a/src/pcs/id/mod.rs
+++ b/src/pcs/id/mod.rs
@@ -94,6 +94,7 @@ impl PcsParams for () {
 }
 
 
+#[derive(Clone)]
 pub struct IdentityCommitment {}
 
 impl<F: PrimeField> PCS<F> for IdentityCommitment {

--- a/src/pcs/kzg/mod.rs
+++ b/src/pcs/kzg/mod.rs
@@ -19,6 +19,7 @@ pub mod params;
 mod commitment;
 mod lagrange;
 
+#[derive(Clone)]
 pub struct KZG<E: Pairing> {
     _engine: PhantomData<E>,
 }


### PR DESCRIPTION
Companion for https://github.com/w3f/ring-proof/pull/6