### PR TITLE
Finish no-std port

### DIFF
--- a/src/aggregation/merlin.rs
+++ b/src/aggregation/merlin.rs
@@ -1,5 +1,6 @@
 use ark_ff::PrimeField;
 use ark_serialize::{CanonicalSerialize, Compress};
+use ark_std::vec;
 
 use crate::aggregation::multiple::Transcript;
 use crate::pcs::PCS;

--- a/src/aggregation/multiple.rs
+++ b/src/aggregation/multiple.rs
@@ -1,9 +1,9 @@
-use std::collections::HashSet;
-
 use ark_ff::PrimeField;
 use ark_poly::Polynomial;
 use ark_std::{end_timer, start_timer};
+use ark_std::{vec, vec::Vec};
 use ark_std::iterable::Iterable;
+use ark_std::collections::BTreeSet;
 
 use crate::{EuclideanPolynomial, Poly, utils};
 use crate::pcs::{Commitment, PCS};
@@ -26,7 +26,7 @@ pub trait Transcript<F: PrimeField, CS: PCS<F>> {
 pub fn aggregate_polys<F: PrimeField, CS: PCS<F>, T: Transcript<F, CS>>(
     ck: &CS::CK,
     fs: &[Poly<F>],
-    xss: &[HashSet<F>],
+    xss: &[BTreeSet<F>],
     transcript: &mut T,
 ) -> (Poly<F>, F, CS::C) {
     assert_eq!(xss.len(), fs.len(), "{} opening sets specified for {} polynomials", xss.len(), fs.len());
@@ -204,8 +204,8 @@ mod tests {
         let xss = random_xss(rng, t, max_m);
         let opening = random_opening::<_, _, CS>(rng, &ck, d, t, xss);
 
-        let sets_of_xss: Vec<HashSet<F>> = opening.xss.iter()
-            .map(|xs| HashSet::from_iter(xs.iter().cloned()))
+        let sets_of_xss: Vec<BTreeSet<F>> = opening.xss.iter()
+            .map(|xs| BTreeSet::from_iter(xs.iter().cloned()))
             .collect();
 
         let transcript = &mut (F::rand(rng), F::rand(rng));

--- a/src/aggregation/single.rs
+++ b/src/aggregation/single.rs
@@ -1,6 +1,7 @@
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{PrimeField, Zero};
 use ark_poly::Polynomial;
+use ark_std::vec::Vec;
 
 use crate::pcs::{Commitment, PCS};
 use crate::Poly;

--- a/src/fflonk.rs
+++ b/src/fflonk.rs
@@ -7,6 +7,7 @@ use ark_poly::DenseUVPolynomial;
 use ark_std::convert::TryInto;
 use ark_std::marker::PhantomData;
 use ark_std::ops::Div;
+use ark_std::{vec, vec::Vec};
 
 use crate::utils;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
-use std::marker::PhantomData;
+#![cfg_attr(not(feature = "std"), no_std)]
 
 use ark_ff::PrimeField;
 use ark_poly::univariate::{DenseOrSparsePolynomial, DensePolynomial};
 use ark_std::rand::Rng;
+use ark_std::vec::Vec;
+use ark_std::marker::PhantomData;
 
 use aggregation::multiple::Transcript;
 
@@ -121,6 +123,7 @@ mod tests {
     use ark_poly::{DenseUVPolynomial, Polynomial};
     use ark_std::rand::Rng;
     use ark_std::test_rng;
+    use ark_std::vec;
 
     use crate::pcs::IdentityCommitment;
     use crate::pcs::kzg::KZG;

--- a/src/pcs/id/mod.rs
+++ b/src/pcs/id/mod.rs
@@ -1,6 +1,7 @@
 use ark_ff::Zero;
 use ark_poly::Polynomial;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::vec::Vec;
 
 use crate::pcs::*;
 use crate::Poly;

--- a/src/pcs/kzg/commitment.rs
+++ b/src/pcs/kzg/commitment.rs
@@ -3,6 +3,7 @@ use ark_ec::pairing::Pairing;
 use ark_serialize::*;
 use ark_std::iter::Sum;
 use ark_std::ops::{Add, Mul, Sub};
+use ark_std::vec::Vec;
 
 use crate::pcs::Commitment;
 use crate::utils::ec::small_multiexp_affine;

--- a/src/pcs/kzg/lagrange.rs
+++ b/src/pcs/kzg/lagrange.rs
@@ -4,6 +4,7 @@ use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::rand::RngCore;
 use ark_std::UniformRand;
+use ark_std::vec::Vec;
 
 use crate::pcs::CommitterKey;
 use crate::pcs::kzg::params::MonomialCK;

--- a/src/pcs/kzg/mod.rs
+++ b/src/pcs/kzg/mod.rs
@@ -6,6 +6,7 @@ use ark_poly::{DenseUVPolynomial, Evaluations, Polynomial};
 use ark_std::marker::PhantomData;
 use ark_std::ops::Mul;
 use ark_std::rand::Rng;
+use ark_std::vec::Vec;
 
 use crate::pcs::{CommitterKey, PCS};
 use crate::pcs::kzg::commitment::KzgCommitment;
@@ -89,7 +90,7 @@ impl<E: Pairing> KZG<E> {
     }
 
     pub fn verify_batch<R: Rng>(openings: Vec<KzgOpening<E>>, vk: &KzgVerifierKey<E>, rng: &mut R) -> bool {
-        let one = std::iter::once(E::ScalarField::one());
+        let one = ark_std::iter::once(E::ScalarField::one());
         let coeffs: Vec<E::ScalarField> = one.chain((1..openings.len()).map(|_| u128::rand(rng).into())).collect();
         let acc_opening = Self::accumulate(openings, &coeffs, vk);
         Self::verify_accumulated(acc_opening, vk)
@@ -154,6 +155,7 @@ mod tests {
     use ark_poly::{DenseUVPolynomial, EvaluationDomain, GeneralEvaluationDomain};
     use ark_std::{end_timer, start_timer};
     use ark_std::test_rng;
+    use ark_std::vec;
 
     use crate::pcs::PcsParams;
     use crate::tests::{BenchCurve, TestCurve, TestField};

--- a/src/pcs/kzg/params.rs
+++ b/src/pcs/kzg/params.rs
@@ -2,6 +2,7 @@ use ark_ec::AffineRepr;
 use ark_ec::pairing::Pairing;
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 use ark_serialize::*;
+use ark_std::{vec, vec::Vec};
 
 use crate::pcs::{CommitterKey, PcsParams, RawVerifierKey, VerifierKey};
 use crate::pcs::kzg::lagrange::LagrangianCK;

--- a/src/pcs/kzg/urs.rs
+++ b/src/pcs/kzg/urs.rs
@@ -3,6 +3,7 @@ use ark_ff::{FftField, UniformRand};
 use ark_serialize::*;
 use ark_std::{end_timer, start_timer};
 use ark_std::rand::RngCore;
+use ark_std::vec::Vec;
 
 use crate::utils;
 use crate::utils::ec::single_base_msm;

--- a/src/pcs/mod.rs
+++ b/src/pcs/mod.rs
@@ -5,6 +5,7 @@ use ark_std::fmt::Debug;
 use ark_std::iter::Sum;
 use ark_std::ops::{Add, Sub};
 use ark_std::rand::Rng;
+use ark_std::vec::Vec;
 
 pub use id::IdentityCommitment;
 

--- a/src/shplonk.rs
+++ b/src/shplonk.rs
@@ -1,9 +1,9 @@
-use std::collections::HashSet;
-use std::marker::PhantomData;
-
 use ark_ff::PrimeField;
 use ark_poly::{DenseUVPolynomial, Polynomial};
 use ark_serialize::*;
+use ark_std::vec::Vec;
+use ark_std::marker::PhantomData;
+use ark_std::collections::BTreeSet;
 
 use crate::aggregation::multiple::{aggregate_claims, aggregate_polys, group_by_commitment, Transcript};
 use crate::pcs::PCS;
@@ -24,7 +24,7 @@ impl<F: PrimeField, CS: PCS<F>> Shplonk<F, CS> {
     pub fn open_many<T: Transcript<F, CS>>(
         ck: &CS::CK,
         fs: &[Poly<F>],
-        xss: &[HashSet<F>],
+        xss: &[BTreeSet<F>],
         transcript: &mut T,
     ) -> AggregateProof<F, CS>
     {
@@ -127,8 +127,8 @@ pub(crate) mod tests {
         let xss = random_xss(rng, t, max_m);
         let opening = random_opening::<_, _, CS>(rng, &params.ck(), d, t, xss);
 
-        let sets_of_xss: Vec<HashSet<F>> = opening.xss.iter()
-            .map(|xs| HashSet::from_iter(xs.iter().cloned()))
+        let sets_of_xss: Vec<BTreeSet<F>> = opening.xss.iter()
+            .map(|xs| BTreeSet::from_iter(xs.iter().cloned()))
             .collect();
 
         let transcript = &mut (F::rand(rng), F::rand(rng));

--- a/src/utils/ec.rs
+++ b/src/utils/ec.rs
@@ -1,6 +1,7 @@
 use ark_ec::{AffineRepr, CurveGroup, Group};
 use ark_ec::scalar_mul::fixed_base::FixedBase;
 use ark_ff::{BigInteger, PrimeField, Zero};
+use ark_std::vec::Vec;
 
 pub fn naive_multiexp_affine<G: AffineRepr>(coeffs: &[G::ScalarField], bases: &[G]) -> G::Group {
     bases.iter().zip(coeffs.iter()).map(|(b, &c)| b.mul(c)).sum()

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -13,7 +13,7 @@ pub fn powers<F: Field>(base: F) -> impl Iterator<Item=F> {
 
 pub fn curve_name<E: Pairing>() -> &'static str {
     // ark_ec::models::bw6::BW6<ark_bw6_761::curves::Parameters>
-    let full_name = std::any::type_name::<E>();
+    let full_name = ark_std::any::type_name::<E>();
     full_name.split_once("<").unwrap().1
         .split_once(":").unwrap().0
 }

--- a/src/utils/poly.rs
+++ b/src/utils/poly.rs
@@ -1,6 +1,7 @@
 use ark_ff::{FftField, Field, PrimeField, Zero};
 use ark_poly::{DenseUVPolynomial, Polynomial};
 use ark_poly::polynomial::univariate::DensePolynomial;
+use ark_std::{vec, vec::Vec};
 
 use crate::Poly;
 use crate::utils::powers;


### PR DESCRIPTION
The crate was not `no-std` yet.

- missing: `#![cfg_attr(not(feature = "std"), no_std)]`
- use required std types via `ark-std::...`
- replace `HashSet` with `BTreeSet`.

`HashSet` is not available in `no_std` environments. Use `BTreeSet` instead
Ref. https://stackoverflow.com/questions/65469712/what-do-i-replace-vec-and-hashset-with-in-a-no-std-environmement

