### PR TITLE
Allow usage of optimized MSM

### DIFF
--- a/src/pcs/kzg/mod.rs
+++ b/src/pcs/kzg/mod.rs
@@ -97,7 +97,10 @@ impl<E: Pairing> KZG<E> {
     }
 
     fn _commit(coeffs: &[E::ScalarField], bases: &[E::G1Affine]) -> KzgCommitment<E> {
-        let proj: E::G1 = VariableBaseMSM::msm_unchecked(bases, coeffs);
+        // `msm` allows to call into implementation of `VariableBaseMSM` for `Projective.
+        // This allows to call into custom implementations of `msm` (`msm_unchecked` not).
+        let len = usize::min(coeffs.len(), bases.len());
+        let proj = <E::G1 as VariableBaseMSM>::msm(&bases[..len], &coeffs[..len]).unwrap();
         KzgCommitment(proj.into_affine())
     }
 }


### PR DESCRIPTION
The implementation was using the "catch all" implementation provided by the `VariableBaseMSM` definition:

https://github.com/arkworks-rs/algebra/blob/993a4e7ca4ac495c733397dcb7a881b53ab1b18d/ec/src/scalar_mul/variable_base/mod.rs#L20-L25

As described [here](https://github.com/arkworks-rs/algebra/blob/993a4e7ca4ac495c733397dcb7a881b53ab1b18d/ec/README.md?plain=1#L75-L76) we can (if provided) leverage some specialized implementation provided by the user.

Indeed in our case we provide this specialized implementation (i.e. the one which jumps into the host functions).

In practice with this patch we jump here:
https://github.com/arkworks-rs/algebra/blob/993a4e7ca4ac495c733397dcb7a881b53ab1b18d/ec/src/models/short_weierstrass/group.rs#L646-L650

And that jumps into the `msm` implementation provided by the user `SWCurveConfig` (in our case host functions)...

---

Notes:
1. the `SWCurveConfig::msm` requires the two inputs to be the same length. We satisfy this requirement before jumping into it.
2. Other failures can be returned (it returns a `Result`). But the one provided by the HF should be infallible... as it just returns `Projective::zero` on failure. But maybe as a follow up we should return a `Result` from `_commit` method

---

Speedup (when executed in wasm) for `(ProverKey, VerifierKey)` construction from `KZG` (i.e. the [`index`](https://github.com/w3f/ring-proof/blob/edd1e90b847e560bf60fc2e8712235ccfa11a9a9/ring/src/piop/mod.rs#L119) function) with a "release" build:
- Previous: ~ 2.5 seconds
- Now: ~ 50 milliseconds (~50x speedup 🚀)


cc @swasilyev @burdges
